### PR TITLE
bug(header): fixed menu extending past screen width

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+/public

--- a/templates/macros/header.html
+++ b/templates/macros/header.html
@@ -7,7 +7,7 @@
 {% endmacro %}
 
 {% macro header(current_section) %}
-<div class="ui borderless huge menu">
+<div class="ui borderless stackable huge menu">
   <a class={{ macros_header::item(current_section=current_section, section="/") }} href="/">
     Macroquad
   </a>


### PR DESCRIPTION
Added menu style class "stacked" to prevent it from extending the viewport from being greater than screen width.
Added /public to .gitignore to prevent default "zola serve" builds from being tracked.

### Why Stacked?
Stacking the menu items when the screen width is small allows the use of vertical space on devices that have limited horizontal space.

### Alternative
Making the menu items be collapsed into a dropdown menu when they cannot be fully shown due to the screen width limitations.