### PR TITLE
removed `-` from not-fl3

### DIFF
--- a/docs/articles/android/index.html
+++ b/docs/articles/android/index.html
@@ -152,7 +152,7 @@ $(document).ready(function(){
 <h1 id="2-setting-up-your-environment"><a class="zola-anchor" href="#2-setting-up-your-environment" aria-label="Anchor link for: 2-setting-up-your-environment">🔗</a>2. Setting up your Environment</h1>
 <h2 id="a-docker-way"><a class="zola-anchor" href="#a-docker-way" aria-label="Anchor link for: a-docker-way">🔗</a>A docker way</h2>
 <p>On the machine with docker pulling all the NDK dependencies is as simple as</p>
-<pre style="background-color:#ffffff;color:#323232;"><code><span>docker pull not-fl3/cargo-apk
+<pre style="background-color:#ffffff;color:#323232;"><code><span>docker pull notfl3/cargo-apk
 </span></code></pre>
 <p>Docker is a recommended way to build macroquad's game for Android. </p>
 <h3 id="building-an-apk-a-docker-way"><a class="zola-anchor" href="#building-an-apk-a-docker-way" aria-label="Anchor link for: building-an-apk-a-docker-way">🔗</a>Building an APK, a docker way</h3>


### PR DESCRIPTION
The username on hub.docker.com is `notfl3` and doesn't include a `-`. running `docker pull not-fl3/cargo-apk`  says: _repository does not exist_.