### PR TITLE
Run zola check on PRs

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -1,8 +1,7 @@
-name: Zola
+name: Zola (Check)
 
 on:
-  push:
-    branches: source
+  pull_request:
 
 jobs:
   zola:
@@ -18,9 +17,4 @@ jobs:
       - name: Install Zola
         run: curl -L ${BASE_URL}/${VERS}/zola-${VERS}-${ARCH}.tar.gz | tar -xz
       - run: ./zola --version
-      - run: ./zola build
-      - name: Deploy
-        uses: crazy-max/ghaction-github-pages@v1
-        with:
-          build_dir: public
-          target_branch: master
+      - run: ./zola check

--- a/config.toml
+++ b/config.toml
@@ -19,6 +19,10 @@ theme_color = "#fff"
 timeformat = "%B %e, %Y" # e.g. June 14, 2021
 timezone = "America/New_York"
 
+[link_checker]
+# TODO: fix all broken links and make this "error"
+external_level = "warn"
+
 # The homepage contents
 [extra.home]
 title = "Macroquad"

--- a/content/articles/android/index.md
+++ b/content/articles/android/index.md
@@ -299,7 +299,7 @@ It may be verified with
 apksigner verify my-app.apk
 
 ```
-[The official documentation on signing can be found here.](https://developer.android.com/studio/publish/app-signing.html#signing-manually).
+[The official documentation on signing can be found here.](https://developer.android.com/studio/publish/app-signing.html).
 
 ## NOTE: how to get `keytool`/`apksigner` with docker
 

--- a/content/articles/fish_tutorial.md
+++ b/content/articles/fish_tutorial.md
@@ -91,7 +91,7 @@ If instead of a window, we have some errors: Maybe some native dependency is mis
 ```bash
 apt install libx11-dev libxi-dev libgl1-mesa-dev
 ```
-For more details, check the [build instructions](https://github.com/not-fl3/macroquad/#building-instructions).
+For more details, check the [build instructions](https://github.com/not-fl3/macroquad/?tab=readme-ov-file#build-instructions).
 
 ## Making game levels
 
@@ -434,7 +434,7 @@ async fn main() {
 
 ## Authentication and registration
 
-Macroquad uses the immediate mode gui concept for UI. Here we will skip GUI style setup (it may be found [here](https://github.com/heroiclabs/fishgame-macroquad/blob/master/src/gui.rs#L36)), and we will proceed to the UI logic instead.
+Macroquad uses the immediate mode gui concept for UI. Here we will skip GUI style setup (it may be found [here](https://github.com/heroiclabs/fishgame-macroquad/blob/25a9872b540035f2998f8624eba5423066d4715d/src/gui.rs#L34-L43)), and we will proceed to the UI logic instead.
 
 <img src="/fishgame_tutorial/login.png"  width="100%"/>
 
@@ -523,7 +523,7 @@ This will be addressed in the [Ready window](#Ready-window) section.
 
 You can use the Matchmaker to find other players. It is possible to match them using properties and a query that specifies the values the other players' properties should hold. In `nakama-rs` the Matchmaker is a `struct` and can be created using `Matchmaker::new()`. There are two types of properties, string properties and numeric properties that can be added with `matchmaker.add_string_property("name", "value")` and `matchmaker.add_numeric_property("rank", 1000.0)` respectively. Names of properties should be unique across both types.
 
-The query is a space-separated string using the [Bleve Query-String-Query Syntax](http://blevesearch.com/docs/Query-String-Query/). It is possible to add queries manually using `matchmaker.add_query_item("properties.region:Europe")` but `nakama-rs` provides a helper to construct the query string using the builder pattern. For now, terms, numeric ranges, required, optional and exclusion are supported. See [examples/matchmaker.rs](https://github.com/heroiclabs/nakama-rs/blob/master/examples/matchmaker.rs) for more examples.
+The query is a space-separated string using the [Bleve Query-String-Query Syntax](http://blevesearch.com/docs/Query-String-Query/). It is possible to add queries manually using `matchmaker.add_query_item("properties.region:Europe")` but `nakama-rs` provides a helper to construct the query string using the builder pattern. For now, terms, numeric ranges, required, optional and exclusion are supported.
 
 ```rust=
 // By default query items are optional. The Matchmaker will prefer


### PR DESCRIPTION
this helps us ensure contributions are those where the site builds and
that the links are valid.

before the workflow for deploy was running and failing for contributions. this
will be more useful. plus we only want to deploy when merged into `source`

in the future previews of PRs would be nice but this is better than before

`zola check` also ensures that URLs are valid, which is quite helpful! We don't
want broken links. There are unfortunately some broken links, which I'd like to
fix. But that'll take a little time, so for now external links just warn
instead of error.
